### PR TITLE
Advance sync cursors per client that received the broadcast

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1168,6 +1168,20 @@ void MyMesh::commitHistoryForClient(const char* client_id, uint32_t seq) {
   }
 }
 
+void MyMesh::commitHistoryForClientsInMask(uint32_t mask, uint32_t seq) {
+  if (mask == 0 || seq == 0) return;
+  int slots = _serial->getClientSlotCount();
+  if (slots > 32) slots = 32;
+  char cid[MAX_CLIENT_ID_LEN + 1];
+  for (int slot = 0; slot < slots; slot++) {
+    if ((mask & (1u << slot)) == 0) continue;
+    _serial->getClientIdForSlot(slot, cid, sizeof(cid));
+    if (cid[0] == 0) continue;
+    if (!shouldAdvanceClientAfterV3Broadcast(cid)) continue;  // legacy clients keep replay
+    commitHistoryForClient(cid, seq);
+  }
+}
+
 void MyMesh::advanceHistoryClientsAfterV3Broadcast(uint32_t seq) {
   for (int i = 0; i < history_num_clients; i++) {
     if (!shouldAdvanceClientAfterV3Broadcast(history_clients[i].client_id))
@@ -1803,9 +1817,9 @@ void MyMesh::queueMessage(const ContactInfo &from, uint8_t txt_type, mesh::Packe
   uint32_t hist_seq = addToHistoryRing(out_frame, i);
 
   if (_serial->isConnected()) {
-    if (_serial->writeFrameToAll(out_frame, i) == (size_t)i && hist_seq != 0 &&
-        _serial->companionUnsolicitedPushesBroadcastToAll()) {
-      advanceHistoryClientsAfterV3Broadcast(hist_seq);
+    uint32_t delivered = _serial->writeFrameToAllMask(out_frame, i);
+    if (delivered != 0 && hist_seq != 0) {
+      commitHistoryForClientsInMask(delivered, hist_seq);
     }
     uint8_t frame[1];
     frame[0] = PUSH_CODE_MSG_WAITING; // send push 'tickle'
@@ -1952,9 +1966,9 @@ void MyMesh::onChannelMessageRecv(const mesh::GroupChannel &channel, mesh::Packe
   i += tlen;
   uint32_t hist_seq = addToHistoryRing(out_frame, i);
   if (_serial->isConnected()) {
-    if (_serial->writeFrameToAll(out_frame, i) == (size_t)i && hist_seq != 0 &&
-        _serial->companionUnsolicitedPushesBroadcastToAll()) {
-      advanceHistoryClientsAfterV3Broadcast(hist_seq);
+    uint32_t delivered = _serial->writeFrameToAllMask(out_frame, i);
+    if (delivered != 0 && hist_seq != 0) {
+      commitHistoryForClientsInMask(delivered, hist_seq);
     }
     uint8_t frame[1];
     frame[0] = PUSH_CODE_MSG_WAITING; // send push 'tickle'

--- a/examples/companion_radio/MyMesh.h
+++ b/examples/companion_radio/MyMesh.h
@@ -675,6 +675,9 @@ private:
   /** Get next history frame for client. If do_advance is false, does not advance last_delivered_seq (call commitHistoryForClient after successful write). */
   int getNextFromHistoryForClient(const char* client_id, uint8_t frame[], uint32_t* out_seq = nullptr, bool do_advance = true);
   void commitHistoryForClient(const char* client_id, uint32_t seq);
+  /** Advance sync cursors for exactly the clients a broadcast actually reached.
+   *  mask comes from BaseSerialInterface::writeFrameToAllMask(). */
+  void commitHistoryForClientsInMask(uint32_t mask, uint32_t seq);
   /** After a successful V3 live broadcast, bump sync watermarks for clients that understand V3 on the wire (target_ver >= 3 or unknown 0xFF).
    *  Legacy apps (CMD_DEVICE_QUERY second byte < 3) are skipped so CMD_SYNC_NEXT_MESSAGE can still deliver adapted 7/8 they never got from live 16/17. */
   void advanceHistoryClientsAfterV3Broadcast(uint32_t seq);

--- a/src/helpers/BaseSerialInterface.h
+++ b/src/helpers/BaseSerialInterface.h
@@ -19,6 +19,19 @@ public:
   virtual size_t writeFrame(const uint8_t src[], size_t len) = 0;
   // Unsolicited push to all connections (multi-transport: USB + all TCP). Default: same as writeFrame.
   virtual size_t writeFrameToAll(const uint8_t src[], size_t len) { return writeFrame(src, len); }
+  /** Broadcast like writeFrameToAll(), but report WHICH client slots received the frame.
+   *  Bit N corresponds to slot N as used by getClientIdForSlot(). Returns 0 if nothing was written.
+   *  Lets callers advance per-client sync cursors only for clients that actually got the frame,
+   *  instead of gating every cursor on all clients succeeding. */
+  virtual uint32_t writeFrameToAllMask(const uint8_t src[], size_t len) {
+    return writeFrameToAll(src, len) == len ? 0x1u : 0u;
+  }
+  /** Client id for a slot reported by writeFrameToAllMask(). Default: the current client. */
+  virtual void getClientIdForSlot(int slot, char* dest, size_t max_len) const {
+    (void)slot; getCurrentClientId(dest, max_len);
+  }
+  /** Number of slots writeFrameToAllMask() can report. */
+  virtual int getClientSlotCount() const { return 1; }
   virtual size_t checkRecvFrame(uint8_t dest[]) = 0;
 
   // TCP only (multi-transport): enable/disable TCP server; no-op for single transport.

--- a/src/helpers/esp32/MultiTransportCompanionInterface.cpp
+++ b/src/helpers/esp32/MultiTransportCompanionInterface.cpp
@@ -362,10 +362,55 @@ void MultiTransportCompanionInterface::setCurrentClientId(const char* id) {
   }
 }
 
+int MultiTransportCompanionInterface::_tcpSlotBase() const {
+#ifdef BLE_PIN_CODE
+  return 2;   // usb, ble
+#else
+  return 1;   // usb
+#endif
+}
+
+uint32_t MultiTransportCompanionInterface::writeFrameToAllMask(const uint8_t src[], size_t len) {
+  if (len > MAX_FRAME_SIZE) return 0;
+  if (!_broadcast) {
+    // Not broadcasting: only the current reply target receives it.
+    if (writeFrame(src, len) != len) return 0;
+    int slot = _clientIdSlot();
+    return (slot >= 0 && slot < 32) ? (1u << slot) : 0u;
+  }
+  uint32_t mask = 0;
+  const int base = _tcpSlotBase();
+  if (_usb.isConnected() && _usb.writeFrame(src, len) == len)
+    mask |= (1u << 0);
+#ifdef BLE_PIN_CODE
+  if (_ble_begun && _ble_enabled && _ble.isConnected() && _ble.writeFrame(src, len) == len)
+    mask |= (1u << 1);
+#endif
+  if (_tcp_started && _tcp.connectedCount() > 0)
+    mask |= (_tcp.writeToAllClientsMask(src, len) << base);
+  if (_ws_started && _ws.connectedCount() > 0) {
+    // WebSocket server exposes no per-client result; treat it as all-or-nothing.
+    if (_ws.writeToAllClients(src, len) == len) {
+      for (int i = 0; i < WS_COMPANION_MAX_CLIENTS; i++) {
+        int slot = base + TCP_COMPANION_MAX_CLIENTS + i;
+        if (slot < 32) mask |= (1u << slot);
+      }
+    }
+  }
+  return mask;
+}
+
+void MultiTransportCompanionInterface::getClientIdForSlot(int slot, char* dest, size_t max_len) const {
+  _clientIdForSlot(slot, dest, max_len);
+}
+
 void MultiTransportCompanionInterface::getCurrentClientId(char* dest, size_t max_len) const {
+  _clientIdForSlot(_clientIdSlot(), dest, max_len);
+}
+
+void MultiTransportCompanionInterface::_clientIdForSlot(int slot, char* dest, size_t max_len) const {
   if (!dest || max_len == 0) return;
   dest[0] = '\0';
-  int slot = _clientIdSlot();
   if (slot < 0 || slot >= (int)(sizeof(_client_ids) / sizeof(_client_ids[0]))) return;
   // If app sent client_id in CMD_APP_START, use it; otherwise use connection-based id
   // so non-custom clients (HA, MeshCore app) still get per-connection history without sending anything.

--- a/src/helpers/esp32/MultiTransportCompanionInterface.h
+++ b/src/helpers/esp32/MultiTransportCompanionInterface.h
@@ -64,6 +64,11 @@ public:
   bool isWriteBusy() const override;
   size_t writeFrame(const uint8_t src[], size_t len) override;
   size_t writeFrameToAll(const uint8_t src[], size_t len) override;
+  uint32_t writeFrameToAllMask(const uint8_t src[], size_t len) override;
+  void getClientIdForSlot(int slot, char* dest, size_t max_len) const override;
+  int getClientSlotCount() const override {
+    return (int)(sizeof(_client_ids) / sizeof(_client_ids[0]));
+  }
   bool companionUnsolicitedPushesBroadcastToAll() const override { return _broadcast; }
   size_t checkRecvFrame(uint8_t dest[]) override;
 
@@ -75,6 +80,9 @@ public:
 
 private:
   int _clientIdSlot() const;
+  /** First mask bit belonging to the TCP client block (usb[, ble] come first). */
+  int _tcpSlotBase() const;
+  void _clientIdForSlot(int slot, char* dest, size_t max_len) const;
   static const size_t _max_client_id_len = 32;
 
   ArduinoSerialInterface _usb;

--- a/src/helpers/esp32/TCPCompanionServer.cpp
+++ b/src/helpers/esp32/TCPCompanionServer.cpp
@@ -167,6 +167,17 @@ size_t TCPCompanionServer::writeToClient(int client_index, const uint8_t src[], 
   return len;
 }
 
+uint32_t TCPCompanionServer::writeToAllClientsMask(const uint8_t src[], size_t len) {
+  if (len == 0 || len > MAX_FRAME_SIZE) return 0;
+  uint32_t mask = 0;
+  for (int i = 0; i < TCP_COMPANION_MAX_CLIENTS; i++) {
+    if (_clients[i].in_use && _clients[i].client.connected()) {
+      if (writeToClient(i, src, len) == len) mask |= (1u << i);
+    }
+  }
+  return mask;
+}
+
 size_t TCPCompanionServer::writeToAllClients(const uint8_t src[], size_t len) {
   if (len == 0 || len > MAX_FRAME_SIZE) return 0;
   int connected = 0;

--- a/src/helpers/esp32/TCPCompanionServer.h
+++ b/src/helpers/esp32/TCPCompanionServer.h
@@ -38,6 +38,10 @@ public:
   // otherwise returns 0.
   size_t writeToAllClients(const uint8_t src[], size_t len);
 
+  // Like writeToAllClients(), but returns a bitmask of client indices that received the frame.
+  // Bit i is set when client i was written successfully. Returns 0 when none were.
+  uint32_t writeToAllClientsMask(const uint8_t src[], size_t len);
+
   bool isClientConnected(int client_index) const;
   int connectedCount() const;
   void disconnectClient(int client_index);


### PR DESCRIPTION
Draft. **This has never been compiled** — I have no ESP32 toolchain to hand, so please treat it as a concrete proposal for the shape rather than a merge candidate. Entirely happy for you to take the idea and write it your own way, or to tell me to rework it. Refs #42.

## The bug

The history cursor advance is gated on the broadcast reaching *every* connected client:

```cpp
if (_serial->writeFrameToAll(out_frame, i) == (size_t)i && hist_seq != 0 &&
    _serial->companionUnsolicitedPushesBroadcastToAll()) {
  advanceHistoryClientsAfterV3Broadcast(hist_seq);
}
```

and `writeToAllClients()` returns 0 unless every write succeeded:

```cpp
return (sent == connected) ? len : 0;
```

With a single client that's invisible — one write essentially always succeeds. With two, one transient failure (TCP backpressure, BLE congestion, a busy phone) returns 0 and **no client's cursor advances**, which produces both reported symptoms at once:

- **Duplicate** — the client that *did* receive the frame re-pulls it from the ring on the next `CMD_SYNC_NEXT_MESSAGE`, because its cursor never moved.
- **Loss** — the client that missed it can have the entry evicted from the 128-entry ring before it next syncs. In a busy region that's minutes.

It also explains why it's transport-independent and asymmetric between clients.

## The change

Report *which* clients received the frame, and advance only those cursors.

- `writeFrameToAllMask()` on `BaseSerialInterface`, returning a bitmask of client slots. Default implementation preserves existing behaviour, so other implementations are unaffected.
- `getClientIdForSlot()` / `getClientSlotCount()` to map mask bits back to the client ids the history ring already uses.
- `TCPCompanionServer::writeToAllClientsMask()` alongside the existing all-or-nothing variant.
- `MyMesh::commitHistoryForClientsInMask()` at the two broadcast call sites, still honouring `shouldAdvanceClientAfterV3Broadcast()` so legacy clients keep their replay.

`getCurrentClientId()` is refactored onto a shared `_clientIdForSlot()` helper; behaviour is unchanged.

## Known gaps

- **Not compiled, not run.** Please assume there are build errors.
- **WebSocket stays all-or-nothing.** `WebSocketCompanionServer` has no per-client write result, so all WS bits are set only when its `writeToAllClients()` fully succeeds. Adding a mask variant there would be the obvious follow-up.
- The mask is 32 bits, which comfortably covers `usb + ble + 3 TCP + 2 WS`, but it's an implicit ceiling worth noting.
- I've left `companionUnsolicitedPushesBroadcastToAll()` in place since other callers use it, though the new path no longer needs it.

Reported from a Heltec V3 with Home Assistant on TCP:5000 plus the MeshCore app, duplicates arriving 80–200 ms apart. Happy to test any build you produce against that setup.