### PR TITLE
Reject all-blank client_id from CMD_APP_START

### DIFF
--- a/examples/companion_radio/MyMesh.cpp
+++ b/examples/companion_radio/MyMesh.cpp
@@ -1083,6 +1083,17 @@ static bool containsIgnoreCaseAscii(const char* haystack, const char* needle) {
   return false;
 }
 
+// A client_id made only of blanks is not an identity -- it is padding from a stock
+// CMD_APP_START frame being misread as a length-prefixed client_id. Reject it so those
+// clients fall back to their per-connection id instead of all sharing one table slot.
+static bool isBlankClientId(const char* s) {
+  if (!s) return true;
+  for (const char* p = s; *p; ++p) {
+    if (*p != ' ' && *p != '\t') return false;
+  }
+  return true;
+}
+
 static bool appPrefersLiveAdvance(const char* app_name) {
   if (!app_name || !app_name[0]) return false;
   // meshcomod/web clients explicitly identify as mccli / meshcomod-*
@@ -2553,16 +2564,28 @@ void MyMesh::handleCmdFrame(size_t len) {
   } else if (cmd_frame[0] == CMD_APP_START &&
              len >= 8) { // sent when app establishes connection, respond with node ID
     // Optional client_id: byte 1 = length (0 = none), bytes 2..1+len = client_id. Then app_name.
+    //
+    // Stock MeshCore clients (meshcore-py, the MeshCore app, MeshCore ONE) put the protocol
+    // VERSION in byte 1 and 6 bytes of padding in bytes 2..7. This extension therefore read a
+    // 3-byte client_id consisting entirely of spaces, so every stock client shared one identity
+    // and they overwrote each other's entry in proto_clients -- the last client to connect
+    // decided prefer_live_advance for all of them. Treat an all-blank client_id as absent and
+    // fall back to the per-connection id so each connection keeps a distinct identity.
     char* app_name;
+    bool have_client_id = false;
+    char cid_buf[MAX_CLIENT_ID_LEN + 1];
     if (len >= 2 && cmd_frame[1] > 0 && len >= 2 + (size_t)cmd_frame[1]) {
       uint8_t cid_len = cmd_frame[1];
       if (cid_len > MAX_CLIENT_ID_LEN) cid_len = MAX_CLIENT_ID_LEN;
-      char cid_buf[MAX_CLIENT_ID_LEN + 1];
       memcpy(cid_buf, &cmd_frame[2], cid_len);
       cid_buf[cid_len] = '\0';
+      have_client_id = !isBlankClientId(cid_buf);
+    }
+    if (have_client_id) {
       _serial->setCurrentClientId(cid_buf);
       app_name = (char*)&cmd_frame[2 + cmd_frame[1]];
     } else {
+      _serial->setCurrentClientId(NULL);  // fall back to the connection-based id
       app_name = (char*)&cmd_frame[8];
     }
     cmd_frame[len] = 0; // make app_name null terminated


### PR DESCRIPTION
Fixes the root cause of #42, where it's diagnosed in detail with probe output.

## The problem

Stock MeshCore clients send the protocol version in byte 1 of `CMD_APP_START`, then six bytes of padding, then the app name at offset 8. meshcore-py sends:

```
b"\x01\x03      mccli"
```

The optional-client_id extension reads that `0x03` as "client_id is 3 bytes long", takes three spaces of padding as the identity, and starts the app name at offset 5. So every stock client is identified as the string `"   "`.

`prefer_live_advance` is keyed on that string in `proto_clients`, so two stock clients share one slot and the last to connect decides the flag for both.

## Observed effect

With Home Assistant (app `mccli`, `prefer=1`) and MeshCore ONE (`prefer=0`) connected, MeshCore ONE overwrote HA's entry. HA's history cursor stopped advancing, and HA then received every message twice — once from the live broadcast and once from its next sync, ~195 ms apart with identical `sender_timestamp`.

Instrumented build, sixteen clean broadcasts then the collision:

```
PROBE2 APP_START cid='   ' app='   mccli' -> prefer=1
PROBE2   added new slot=0
PROBE2 gate cid='   ' FOUND slot=0 tv=3 prefer=1 -> YES     (seq 1..16, no duplicates)
PROBE2 APP_START cid='   ' app='   MeshC' -> prefer=0
PROBE2   updated existing slot=0
PROBE2 gate cid='   ' FOUND slot=0 tv=3 prefer=0 -> NO      (seq 17, duplicates start)
```

Not HA-specific — any two stock clients collide on `"   "`. The stock MeshCore app happens to escape it by sending byte 1 = 0, which takes the no-client-id path and earns a real per-connection identity.

## The change

Treat an all-blank client_id as absent and fall back to the per-connection id, so each connection keeps a distinct identity. Clients that genuinely send a client_id are unaffected, and the app name lands at the correct offset again (it currently arrives as `'   mccli'` with three leading spaces).

Deliberately minimal — it doesn't change the wire format or the meaning of byte 1.

## Status

Compiles for `Heltec_v3_companion_radio_usb_tcp`. **Not yet runtime-verified**; I'm flashing it now and will report back, and mark this ready for review once I've run it for a while. Opening as a draft until then.

Two larger changes worth considering, entirely your call and not attempted here: keying `prefer_live_advance` on the connection rather than a client-supplied string, and giving the client_id extension an unambiguous marker so it can't collide with the version byte.

I've closed #43. It addresses a real all-or-nothing write-accounting issue, but instrumentation showed it is not the cause of #42 and I didn't want it merged as though it closed that out.