### PR TITLE
Treat associated-but-address-less as a dead WiFi link

### DIFF
--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -475,6 +475,9 @@ void loop() {
   static bool wifi_started = false;
   static uint32_t last_wifi_retry_ms = 0;
   static const uint32_t WIFI_RETRY_INTERVAL_MS = 10000;
+  // How long a station may stay associated with no address before we force a clean
+  // re-association. Longer than a normal DHCP exchange, short enough to self-heal fast.
+  static const uint32_t WIFI_NO_IP_GRACE_MS = 20000;
   static bool wifi_radio_prev = true;
   static bool wifi_radio_inited = false;
   /* BLE-vs-WiFi mutex (chosen at setup based on saved creds + radio_en pref):
@@ -535,7 +538,29 @@ void loop() {
       }
     }
     // Automatic WiFi recovery for TCP mode: retry connection periodically if link drops.
-    if (wifiConfigHasRuntime() && WiFi.status() != WL_CONNECTED) {
+    //
+    // A station can stay associated (WL_CONNECTED) while holding no address: a DHCP lease
+    // that expires without a successful renewal leaves localIP() at 0.0.0.0 while status()
+    // still reports connected. Every TCP/WebSocket listener is then unreachable and the
+    // association-only check below never fires, so the node sits there until rebooted.
+    // Track how long we have been associated without an address and force a clean
+    // re-association past WIFI_NO_IP_GRACE_MS. The grace period avoids tearing down a link
+    // that is merely still completing its initial DHCP exchange.
+    static uint32_t assoc_no_ip_since_ms = 0;
+    bool wifi_assoc = (WiFi.status() == WL_CONNECTED);
+    bool wifi_has_ip = false;
+    if (wifi_assoc) {
+      IPAddress ip = WiFi.localIP();
+      wifi_has_ip = !(ip[0] == 0 && ip[1] == 0 && ip[2] == 0 && ip[3] == 0);
+    }
+    if (!wifi_assoc || wifi_has_ip) {
+      assoc_no_ip_since_ms = 0;
+    } else if (assoc_no_ip_since_ms == 0) {
+      assoc_no_ip_since_ms = millis();
+    }
+    bool wifi_stuck_no_ip = (assoc_no_ip_since_ms != 0) &&
+        ((uint32_t)(millis() - assoc_no_ip_since_ms) >= WIFI_NO_IP_GRACE_MS);
+    if (wifiConfigHasRuntime() && (!wifi_assoc || wifi_stuck_no_ip)) {
       uint32_t now = millis();
       if ((uint32_t)(now - last_wifi_retry_ms) >= WIFI_RETRY_INTERVAL_MS) {
         last_wifi_retry_ms = now;
@@ -544,6 +569,12 @@ void loop() {
         wifiConfigGetSsid(ssid, sizeof(ssid));
         wifiConfigGetPwd(pwd, sizeof(pwd));
         if (strlen(ssid) > 0) {
+          if (wifi_stuck_no_ip) {
+            // Associated but address-less: drop the association so the next begin()
+            // runs a fresh DHCP exchange instead of resuming the dead lease.
+            WiFi.disconnect();
+            assoc_no_ip_since_ms = 0;
+          }
           WiFi.begin(ssid, pwd[0] ? pwd : nullptr);
         }
       }


### PR DESCRIPTION
## The problem

My Heltec V3 became unreachable and I found it sitting at IP `0.0.0.0`. It had a valid DHCP reservation on the router the whole time, and it stayed in that state until I power-cycled it.

The multi-transport recovery loop only checks association:

```cpp
// Automatic WiFi recovery for TCP mode: retry connection periodically if link drops.
if (wifiConfigHasRuntime() && WiFi.status() != WL_CONNECTED) {
```

An ESP32 station can stay associated (`WL_CONNECTED`) while holding no address. A DHCP lease that expires without a successful renewal leaves `localIP()` at `0.0.0.0` with `status()` still reporting connected. In that state every TCP and WebSocket listener is unreachable, the check above never fires, and nothing recovers it short of a reboot.

`WiFi.localIP()` appears four times in the tree and every one is for display. It is never consulted in a recovery decision.

The event-driven reconnect further down is compiled out for these builds:

```cpp
#if defined(ESP32) && defined(WIFI_SSID) && !defined(MULTI_TRANSPORT_COMPANION)
```

so the polling loop is the only recovery path, and it cannot see this failure mode.

## The change

Track how long the station has been associated without an address, and once that exceeds `WIFI_NO_IP_GRACE_MS` (20 s) treat the link as down: `WiFi.disconnect()` then `WiFi.begin()`, so the next attempt runs a fresh DHCP exchange rather than resuming a dead lease.

Deliberately conservative:

- Fires only when associated **and** the address is all zeroes, never on a transient
- The 20 s grace period is well clear of a normal DHCP exchange, so a link still completing its initial handshake is never torn down
- The existing `WIFI_RETRY_INTERVAL_MS` still applies, so at most one attempt per 10 s
- No behaviour change whatsoever on the healthy path

I dropped a `WIFI_DEBUG_PRINTLN` I initially added, since that macro comes from `SerialWifiInterface.h` which multi-transport builds don't include — as the comment at the bottom of the file already notes. Happy to add logging back through whatever mechanism you'd prefer.

## Status

Compiles for `Heltec_v3_companion_radio_usb_tcp`. I'm running it now.

Honest caveat: I can reproduce the *symptom* but not the *trigger* on demand, since I can't easily force a DHCP renewal failure. So this is verified as "does not regress the healthy path and compiles clean" rather than "observed to recover from the failure". The reasoning about `WL_CONNECTED` with no address is well documented ESP32 behaviour, but I'd rather state plainly what I have and haven't confirmed.

Unrelated to #44, which is in the same tree but a completely separate issue.