### PR TITLE
fix: ThinkNode M7 support + three 1.17.0 merge regressions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -45,6 +45,10 @@ $ sh build.sh build-room-server-firmwares
 Environment Variables:
   DISABLE_DEBUG=1: Disables all debug logging flags (MESH_DEBUG, MESH_PACKET_LOGGING, etc.)
                    If not set, debug flags from variant platformio.ini files are used.
+  MERGE_BIN=1:     Also produce out/<env>-<version>-<sha>-merged.bin (bootloader + partitions
+                   + app, flash at 0x0) for ESP32 targets whose env name isn't already merged
+                   by default. Needed for boards outside the release matrix, e.g. ThinkNode M7.
+                   See docs/LOCAL_BUILD_M7.md.
   REPEATER_FIRMWARE_VERSION: For env names ending in _repeater_tcp only, overrides FIRMWARE_VERSION
                    for the compile-time version string and out/ filenames. **Recommended:** repeater train
                    r1.14.1.x — e.g. r1.14.1.0-repeater-tcp (then copy-repeater-release-bins.sh r1.14.1.0).
@@ -203,8 +207,10 @@ build_firmware() {
   # App image only in out/ (flash at partition app offset).
   if [ "$ENV_PLATFORM" == "ESP32_PLATFORM" ]; then
     cp .pio/build/$1/firmware.bin out/${FIRMWARE_FILENAME}.bin 2>/dev/null || true
-    # Companions (USB+TCP) + Heltec TCP repeaters: merged image at 0x0 for flasher / full-chip flash
-    if [[ "$1" == *companion_radio_usb_tcp* ]] || [[ "$1" == *_repeater_tcp ]] || [[ "$1" == *_room_server_multitransport ]]; then
+    # Companions (USB+TCP) + Heltec TCP repeaters: merged image at 0x0 for flasher / full-chip flash.
+    # MERGE_BIN=1 opts any other ESP32 env in, for boards outside the release matrix
+    # (e.g. ThinkNode M7), whose env names match none of the suffixes below.
+    if [ "$MERGE_BIN" = "1" ] || [[ "$1" == *companion_radio_usb_tcp* ]] || [[ "$1" == *_repeater_tcp ]] || [[ "$1" == *_room_server_multitransport ]]; then
       if $PIO_CMD run -t mergebin -e "$1"; then
         if [ -f ".pio/build/$1/firmware-merged.bin" ]; then
           cp ".pio/build/$1/firmware-merged.bin" "out/${FIRMWARE_FILENAME}-merged.bin" 2>/dev/null || true

--- a/docs/LOCAL_BUILD_M7.md
+++ b/docs/LOCAL_BUILD_M7.md
@@ -1,0 +1,131 @@
+# Elecrow ThinkNode M7
+
+The M7 is an ESP32-S3 + LR1110 board with a 100 Mbps RJ45 (WCH CH390 SPI Ethernet
+controller) and optional PoE. `variants/thinknode_m7/` and `boards/thinknode_m7.json`
+arrived with the upstream 1.17.0 merge, but the board is not in meshcomod's release matrix,
+so there is no prebuilt binary and no web-flasher entry (see [CI releases](CI_RELEASES.md)).
+It has to be built from source.
+
+## Environments
+
+`*_companion_radio_usb_tcp` (meshcomod's USB + TCP + WebSocket companion) does not exist for
+this board, so these are upstream's environments.
+
+| Env | Transports | Notes |
+|-----|-----------|-------|
+| `ThinkNode_M7_companion_radio_ethernet` | USB + Ethernet | The PoE wired node. Companion TCP on port 5000 over the wire, USB for config. |
+| `ThinkNode_M7_companion_radio_ble` | BLE | Ethernet flags are set but unused, since BLE takes precedence. See "Remaining gaps". |
+| `ThinkNode_M7_companion_radio_usb` | USB | Simplest bring-up target. |
+| `ThinkNode_M7_companion_radio_wifi` | Wi-Fi (TCP 5000) | SSID/password hardcoded in the variant's `platformio.ini`. |
+| `ThinkNode_M7_kiss_modem` | USB | KISS TNC. |
+| `ThinkNode_M7_repeater` | none | **Does not build.** See "Remaining gaps". |
+
+## Building
+
+```bash
+export FIRMWARE_VERSION=v1.17.0
+MERGE_BIN=1 bash build.sh build-firmware ThinkNode_M7_companion_radio_ethernet
+```
+
+`MERGE_BIN=1` is needed because `build.sh` only produces a merged image automatically for env
+names in the release matrix, and no M7 env matches. Without it you get the app image only.
+
+| Output | Flash at | Contents |
+|--------|----------|----------|
+| `out/<env>-<version>-<sha>-merged.bin` | `0x0` | bootloader + partition table + app |
+| `out/<env>-<version>-<sha>.bin` | `0x10000` | app only, keeps partition table and SPIFFS |
+
+Flash with [esptool-js](https://espressif.github.io/esptool-js/) in Chrome, or:
+
+```bash
+esptool --chip esp32s3 --port <PORT> --baud 921600 write-flash 0x0 out/<file>-merged.bin
+```
+
+The board enumerates as a WCH CH343 bridge (`1a86:7522`), not Espressif native USB, so `<PORT>`
+is typically `/dev/ttyUSB0` on Linux (ch341 driver) or `COMx` on Windows, not `/dev/ttyACM0`.
+Note also that
+`boards/thinknode_m7.json` still declares `hwids` of `0x303A:0x1001`, which breaks PlatformIO's
+automatic port detection. Serial console is 115200. There is no reset button, and the auto-reset
+circuit works, so pulse DTR/RTS (or power cycle) to reset.
+
+A merged image spans `0x0` to `~0x131000`, which covers NVS at `0x9000` but **not** SPIFFS at
+`0x670000`. Node preferences live in `/prefs.json` in SPIFFS, so radio settings survive
+reflashing.
+
+## Radio region
+
+`[arduino_base]` in `platformio.ini` compiles in EU defaults (869.618 MHz / 62.5 kHz / SF8).
+These seed the factory defaults only: companion firmware copies them into `_prefs` on first
+boot and uses stored preferences thereafter, and a client app will typically overwrite them
+during setup. For the headless roles (repeater, room server, KISS modem) there is no app, so
+the compiled values are the operating configuration. Set them explicitly when building those
+for a non-EU region.
+
+## Hardware validation
+
+Verified on a real ThinkNode M7 (this is the first known instance of meshcomod running on the
+board):
+
+- Boots, reporting `[BOOT] board ok` and `[BOOT] radio ok`, so the LR1110 initializes.
+- BLE companion pairs from the MeshCore client.
+- USB companion connects from the web client.
+- Ethernet: link, DHCP lease, `ETH: listening on TCP port: 5000`, USB live simultaneously.
+- Home Assistant connects over the Ethernet TCP transport and reads telemetry.
+- Both LEDs work. Green shows the firmware heartbeat, a 20 ms blip every 4 s that lengthens to
+  200 ms while messages are unread. Blue follows LoRa transmit.
+- The compiled radio defaults seed a fresh device. After the store was cleared the node came up
+  on 927.875 MHz, 62.5 kHz, SF7, CR5 with no client involvement.
+- DHCP-to-DNS registration works. A rename propagated to DNS with no measurable delay, on the
+  same MAC and the same lease.
+
+## Remaining gaps
+
+- **`ThinkNode_M7_repeater` does not compile.** `examples/simple_repeater/UITask.cpp` uses
+  `DisplayDriver::BLUE` and `DisplayDriver::LIGHT`, but that `enum Color` is commented out at
+  `src/helpers/ui/DisplayDriver.h:20`, superseded by the `UIColor` statics. This breaks the
+  plain `*_repeater` envs on **every** board, reproduced identically on
+  `Station_G3_ESP32_repeater`, so it is not M7-specific and wants its own fix.
+- **`ThinkNode_M7_companion_radio_ble` has unused Ethernet.** The env sets both `BLE_PIN_CODE`
+  and the CH390 flags, but the companion registers only BLE. `MultiSerialInterface` supports
+  registering BLE, USB and Ethernet together, and wiring that up would give the board every
+  transport at once.
+- **`examples/companion_radio/ui-tiny/UITask.h`** still declares its constructor as taking
+  `MultiSerialInterface*`, which nothing constructs on nRF52. `LilyGo_T-Echo_Card_companion_radio_ble`
+  and `_usb` carry the same break that this change fixes for `ui-orig`.
+- **`boards/thinknode_m7.json` `hwids`** do not match the hardware (see above).
+- **The ethernet MAC is locally administered.** This platform builds with
+  `CONFIG_ESP32S3_UNIVERSAL_MAC_ADDRESSES=2`, so the ESP-IDF derives the ethernet address from
+  the Bluetooth address with the locally administered bit set. From an illustrative base of
+  `00:00:5E:00:53:00` that gives Bluetooth `00:00:5E:00:53:01` and ethernet `02:00:5E:00:53:01`,
+  which differs from the base in both the first and the last octet and carries no vendor OUI.
+  ESPHome on the same board reports `00:00:5E:00:53:03`, base+3, because it builds with four
+  universal addresses and assigns the ethernet address explicitly with
+  `esp_read_mac(ESP_MAC_ETH)` and `esp_eth_ioctl(ETH_CMD_S_MAC_ADDR)` before attaching the
+  netif. Matching that needs the universal address count changed, since
+  `esp_read_mac(ESP_MAC_ETH)` returns the derived value here and writing it back is a no-op.
+  Changing it moves the address of every deployed unit, discarding whatever the current one is
+  bound to, so it is left alone.
+- **A mains powered device reports a battery.** `ESP32Board::getBattMilliVolts()` returns 0
+  unless `PIN_VBAT_READ` is defined, and the M7 defines no such pin because the board is powered
+  over PoE or USB and carries no cell. Zero is indistinguishable from a flat battery, so every
+  client presents the node as critically discharged. The protocol has no way to say a device has
+  no battery, which is where the fix belongs: a device with no cell should report absence rather
+  than zero, and a board should be able to declare that it is externally powered.
+- **The Home Assistant integration exposes battery entities for a device with no battery.** It
+  creates Battery Percentage and Battery Voltage from that zero, so the node shows 0 percent with
+  a low-battery icon and will drive any automation or alert keyed on battery level. Until the
+  protocol can express absence, those entities should be omitted or reported unavailable for a
+  device that reports no cell rather than published as a real reading.
+- **The meshcomod web client mis-parses the device info frame, and the offset is known.** Byte 2
+  of `RESP_CODE_DEVICE_INFO` is `MAX_CONTACTS / 2`, 175, which is invalid UTF-8, and byte 3 is
+  `MAX_GROUP_CHANNELS`, 40. Those are what the mojibake and the stray bracket are. Bytes 8 to 19
+  hold the build date and bytes 20 on the manufacturer name, which is why they appear run
+  together. The client starts reading at offset 2 rather than offset 8, skipping the two byte
+  header but neither the two v3+ count bytes nor the four byte BLE pin, and does not stop at the
+  null separators. The same client reads `Device model` and `Firmware` correctly from that frame,
+  and Home Assistant renders it correctly, so the frame is well formed and `StrHelper::strzcpy`
+  pads every field. The fix belongs in that client.
+- **The same client reports a battery voltage the firmware never sent.** It has shown 7.04 V,
+  2.56 V and 0.000 V for a board with no cell, where Home Assistant renders 0.000 V from the same
+  device. The firmware reports zero, so the value is invented by that client's parsing and the
+  fix belongs with the frame offset above.

--- a/examples/companion_radio/main.cpp
+++ b/examples/companion_radio/main.cpp
@@ -55,6 +55,46 @@ static uint32_t _atoi(const char* sp) {
   #endif
 #endif
 
+// Ethernet-capable board with none of the other exclusive transports selected.
+// USB and Ethernet run together through MultiSerialInterface, each registered as its own transport.
+// Ordered after BLE_PIN_CODE so the BLE companion envs keep their existing behavior.
+#if defined(ESP32) && defined(ETHERNET_ENABLED) && !defined(MULTI_TRANSPORT_COMPANION) \
+    && !defined(WIFI_SSID) && !defined(BLE_PIN_CODE)
+  #define COMPANION_USB_ETHERNET 1
+
+// The ethernet debug macros print to Serial, which carries the companion protocol here.
+// Their output lands mid-frame and a client decodes it as garbage contacts and messages.
+// Tested by value, matching SerialEthernetInterface, so an explicit zero stays a valid way to disable it.
+#if ETHERNET_DEBUG_LOGGING
+  #error "ETHERNET_DEBUG_LOGGING corrupts the USB companion stream, which shares Serial"
+#endif
+
+// Reduces a node name to an RFC 1123 label, since a name is free text and a hostname is not.
+// Underscore and every other character outside letters and digits becomes a hyphen, and runs collapse.
+// A label cannot open or close on a hyphen, so the edges are trimmed and an empty result falls back.
+// Output is lowercased by convention, names being case-insensitive, and the caller's buffer caps the 63 octet limit.
+// The read is bounded by name_len because node_name can load without a terminator.
+// A skipped character does not advance w, so the output bound does not bound the input.
+static void toHostLabel(const char* name, size_t name_len, char* out, size_t out_len) {
+  if (out == NULL || out_len == 0) return;
+  if (name == NULL) name_len = 0;
+
+  size_t w = 0;
+  for (size_t r = 0; r < name_len && name[r] && w + 1 < out_len; r++) {
+    char c = name[r];
+    if (c >= 'A' && c <= 'Z') c += 32;
+    if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) {
+      out[w++] = c;
+    } else if (w > 0 && out[w - 1] != '-') {
+      out[w++] = '-';
+    }
+  }
+  while (w > 0 && out[w - 1] == '-') w--;
+  out[w] = 0;
+  if (w == 0) StrHelper::strncpy(out, "meshcore", out_len);
+}
+#endif
+
 #ifdef ESP32
   #ifdef MULTI_TRANSPORT_COMPANION
     #include <helpers/esp32/MultiTransportCompanionInterface.h>
@@ -74,6 +114,14 @@ static uint32_t _atoi(const char* sp) {
   #elif defined(BLE_PIN_CODE)
     #include <helpers/esp32/SerialBLEInterface.h>
     SerialBLEInterface serial_interface;
+  #elif defined(COMPANION_USB_ETHERNET)
+    #include <ESPmDNS.h>
+    #include <helpers/MultiSerialInterface.h>
+    #include <helpers/ArduinoSerialInterface.h>
+    #include <helpers/ethernet/EthernetInterface.h>
+    MultiSerialInterface serial_interface;        // fans out to both transports below
+    ArduinoSerialInterface usb_serial_interface;  // config / CLI over USB
+    ETHERNET_CLASS ethernet_interface;            // CH390: DHCP + companion TCP on ETHERNET_TCP_PORT
   #elif defined(SERIAL_RX)
     #include <helpers/ArduinoSerialInterface.h>
     ArduinoSerialInterface serial_interface;
@@ -443,6 +491,29 @@ void setup() {
     WiFi.begin(WIFI_SSID, WIFI_PWD);
   }
   serial_interface.begin(TCP_PORT);
+#elif defined(COMPANION_USB_ETHERNET)
+  usb_serial_interface.begin(Serial);
+  serial_interface.addInterface(InterfaceType::USB, &usb_serial_interface);
+  // A failed begin() means the controller is missing or miswired rather than the cable being unplugged.
+  if (ethernet_interface.begin()) {
+    // A DHCP lease carrying the node name gives a stable name to reach the device by.
+    // Without it the server invents one from the MAC, which can hold a space and resolve nowhere.
+    char hostname[33];
+    NodePrefs* np = the_mesh.getNodePrefs();
+    toHostLabel(np->node_name, sizeof(np->node_name), hostname, sizeof(hostname));
+    bool host_ok = ethernet_interface.setHostname(hostname);
+    // A DHCP hostname only resolves where the server registers it in DNS, which many do not.
+    // An mDNS responder answers for the same label as <name>.local regardless of the server.
+    // The responder starts before the lease arrives and answers once the interface holds an address.
+    bool mdns_ok = MDNS.begin(hostname);
+    if (mdns_ok) MDNS.addService("meshcore", "tcp", ETHERNET_TCP_PORT);
+    serial_interface.addInterface(InterfaceType::Ethernet, &ethernet_interface);
+    // Both results are reported because a silent failure here looks identical to a server that did not register the name.
+    Serial.printf("[BOOT] usb+ethernet ok, hostname '%s' dhcp=%s mdns=%s\n",
+                  hostname, host_ok ? "ok" : "FAILED", mdns_ok ? "ok" : "FAILED");
+  } else {
+    Serial.println("[BOOT] ethernet FAILED (CH390 init) - USB only");
+  }
 #elif defined(BLE_PIN_CODE)
   serial_interface.begin(BLE_NAME_PREFIX, the_mesh.getNodePrefs()->node_name, the_mesh.getBLEPin());
 #elif defined(SERIAL_RX)
@@ -626,6 +697,10 @@ void loop() {
   }
 #endif
   the_mesh.loop();
+#ifdef COMPANION_USB_ETHERNET
+  // Nothing else drives BaseSerialInterface::loop(), which the Ethernet transport needs to accept clients.
+  serial_interface.loop();
+#endif
   sensors.loop();
   rtc_clock.tick();
 

--- a/examples/companion_radio/ui-orig/UITask.h
+++ b/examples/companion_radio/ui-orig/UITask.h
@@ -61,7 +61,10 @@ class UITask : public AbstractUITask {
  
 public:
 
-  UITask(mesh::MainBoard* board, MultiSerialInterface* serial) : AbstractUITask(board, serial), _display(NULL), _sensors(NULL) {
+  // Each env picks a different concrete transport in main.cpp, so only the shared base type fits every call site.
+  // Nothing here touches _serial directly, since AbstractUITask holds it as a BaseSerialInterface.
+  // The ui-new flavor of this class takes the same base type.
+  UITask(mesh::MainBoard* board, BaseSerialInterface* serial) : AbstractUITask(board, serial), _display(NULL), _sensors(NULL) {
       _next_refresh = 0;
       ui_started_at = 0;
   }

--- a/src/helpers/BaseChatMesh.cpp
+++ b/src/helpers/BaseChatMesh.cpp
@@ -64,6 +64,11 @@ void BaseChatMesh::sendAckTo(const ContactInfo& dest, const uint8_t* ack_hash, u
 }
 
 void BaseChatMesh::bootstrapRTCfromContacts() {
+  // Callers arrive with num_contacts seeded to MAX_ANON_CONTACTS while the table is still unallocated.
+  // Without this the loop below walks a null pointer on a device holding no stored contacts.
+  // Allocating here also keeps every later contacts[] reader safe, since begin() runs with PSRAM up.
+  if (!ensureContacts()) return;
+
   uint32_t latest = 0;
   for (int i = 0; i < num_contacts; i++) {
     if (contacts[i].lastmod > latest) {
@@ -75,23 +80,35 @@ void BaseChatMesh::bootstrapRTCfromContacts() {
   }
 }
 
-ContactInfo* BaseChatMesh::allocateContactSlot(bool transient_only) {
-  // Lazily allocate the contact table on first use. On ESP32 we put the table in
-  // PSRAM to keep it off scarce internal DRAM (WiFi needs internal heap). Sized
-  // MAX_CONTACTS + MAX_ANON_CONTACTS to match the upstream array, whose first
-  // MAX_ANON_CONTACTS slots are reserved for transient/anonymous requests.
-  // MUST stay ahead of every contacts[] access below: upstream's array is static
-  // and can be indexed immediately, ours cannot.
-  if (!contacts) {
+// Allocates the contact table on first use, in PSRAM where available to keep it off internal DRAM.
+// Sized MAX_CONTACTS + MAX_ANON_CONTACTS, whose first MAX_ANON_CONTACTS slots hold anonymous requests.
+// Must run ahead of every contacts[] access, and cannot run from the constructor because PSRAM is not up yet.
+bool BaseChatMesh::ensureContacts() {
+  if (contacts) return true;
 #if defined(ESP32)
-    contacts = (ContactInfo*)heap_caps_malloc(sizeof(ContactInfo) * (MAX_CONTACTS+MAX_ANON_CONTACTS), MALLOC_CAP_SPIRAM);
-    if (!contacts) contacts = (ContactInfo*)heap_caps_malloc(sizeof(ContactInfo) * (MAX_CONTACTS+MAX_ANON_CONTACTS), MALLOC_CAP_8BIT);
+  contacts = (ContactInfo*)heap_caps_malloc(sizeof(ContactInfo) * (MAX_CONTACTS+MAX_ANON_CONTACTS), MALLOC_CAP_SPIRAM);
+  if (!contacts) contacts = (ContactInfo*)heap_caps_malloc(sizeof(ContactInfo) * (MAX_CONTACTS+MAX_ANON_CONTACTS), MALLOC_CAP_8BIT);
 #else
-    contacts = (ContactInfo*)malloc(sizeof(ContactInfo) * (MAX_CONTACTS+MAX_ANON_CONTACTS));
+  contacts = (ContactInfo*)malloc(sizeof(ContactInfo) * (MAX_CONTACTS+MAX_ANON_CONTACTS));
 #endif
-    if (!contacts) return NULL;   // out of memory: behave as "no slot"
-    memset(contacts, 0, sizeof(ContactInfo) * (MAX_CONTACTS+MAX_ANON_CONTACTS));
+  if (!contacts) {
+    // Readers loop on num_contacts without allocating first.
+    // Leaving it seeded here would fault exactly as an unallocated table did.
+    num_contacts = 0;
+    return false;
   }
+  memset(contacts, 0, sizeof(ContactInfo) * (MAX_CONTACTS+MAX_ANON_CONTACTS));
+
+  // A failed attempt zeroed the count, so restore the floor that resetContacts() seeds.
+  // Leaving it at zero would hand the reserved anonymous slots out as permanent contacts.
+  if (num_contacts < MAX_ANON_CONTACTS) num_contacts = MAX_ANON_CONTACTS;
+  return true;
+}
+
+ContactInfo* BaseChatMesh::allocateContactSlot(bool transient_only) {
+  // Out of memory behaves as "no slot".
+  if (!ensureContacts()) return NULL;
+
   int oldest_idx = -1;
   uint32_t oldest_lastmod = 0xFFFFFFFF;
   if (transient_only) {

--- a/src/helpers/BaseChatMesh.h
+++ b/src/helpers/BaseChatMesh.h
@@ -115,6 +115,8 @@ protected:
     _txt_last_ts = 0;
   }
 
+  // Allocates the lazily-created contact table, returning false when out of memory.
+  bool ensureContacts();
   void bootstrapRTCfromContacts();
 
   void resetContacts() {
@@ -122,8 +124,14 @@ protected:
     // still null when this runs at construction — upstream's array is static, ours
     // is not. The lazy alloc zeroes the whole table itself, so skipping the memset
     // while unallocated is safe; doing it unguarded NULL-derefs on boot.
-    if (contacts) memset(contacts, 0, sizeof(contacts[0])*MAX_ANON_CONTACTS);   // set all to have type = ADV_TYPE_NONE(0)
-    num_contacts = MAX_ANON_CONTACTS;  // seed the first contacts for anon requests
+    if (contacts) {
+      memset(contacts, 0, sizeof(contacts[0])*MAX_ANON_CONTACTS);   // set all to have type = ADV_TYPE_NONE(0)
+      num_contacts = MAX_ANON_CONTACTS;  // seed the first contacts for anon requests
+    } else {
+      // Every reader loops on this count and indexes the table without allocating first.
+      // Zero keeps them safe until the table exists, and ensureContacts() restores the floor.
+      num_contacts = 0;
+    }
   }
   void populateContactFromAdvert(ContactInfo& ci, const mesh::Identity& id, const AdvertDataParser& parser, uint32_t timestamp);
   ContactInfo* allocateContactSlot(bool transient_only=false); // helper to find slot for new contact
@@ -202,7 +210,8 @@ public:
   bool  removeContact(ContactInfo& contact);
   bool  addContact(const ContactInfo& contact);
   int getTotalContactSlots() const { return num_contacts; }
-  int getNumContacts() const { return num_contacts - MAX_ANON_CONTACTS; }  // don't include the reserved slots at start
+  // Clamped because num_contacts is zeroed when allocation fails, which would otherwise report a negative count.
+  int getNumContacts() const { return num_contacts > MAX_ANON_CONTACTS ? num_contacts - MAX_ANON_CONTACTS : 0; }
   bool getLastTxtTxHash4(uint32_t& out_hash4) const {
     if (!has_last_txt_tx_hash4) return false;
     out_hash4 = last_txt_tx_hash4;

--- a/src/helpers/MultiSerialInterface.h
+++ b/src/helpers/MultiSerialInterface.h
@@ -2,6 +2,17 @@
 
 #include "BaseSerialInterface.h"
 
+// Follows MAX_CLIENT_ID_LEN where the companion has already defined it.
+// Two independent limits let one side be raised while the other truncates a client id.
+// That splits the client's history in a way that presents as message loss.
+#ifndef MULTI_SERIAL_CLIENT_ID_LEN
+  #ifdef MAX_CLIENT_ID_LEN
+    #define MULTI_SERIAL_CLIENT_ID_LEN MAX_CLIENT_ID_LEN
+  #else
+    #define MULTI_SERIAL_CLIENT_ID_LEN 31
+  #endif
+#endif
+
 #ifndef MAX_INTERFACES
   // ble, usb, wifi, ethernet
   #define MAX_INTERFACES 4
@@ -26,6 +37,27 @@ private:
 
   bool _enabled = false;
   RegisteredInterface _interfaces[MAX_INTERFACES] = {};
+
+  // Index of the interface that produced the last received frame, which is where a reply belongs.
+  int _reply_idx = -1;
+  char _client_ids[MAX_INTERFACES][MULTI_SERIAL_CLIENT_ID_LEN + 1] = {};
+
+  bool validIdx(int i) const {
+    return i >= 0 && i < MAX_INTERFACES && _interfaces[i].instance != nullptr;
+  }
+
+  // Gives an unconfigured client a stable per-transport identity.
+  // Without one every transport shares an empty id, and with it a shared history cursor.
+  static const char* defaultClientId(InterfaceType type) {
+    switch (type) {
+      case InterfaceType::USB:            return "usb";
+      case InterfaceType::Bluetooth:      return "ble";
+      case InterfaceType::WiFi:           return "wifi";
+      case InterfaceType::Ethernet:       return "eth";
+      case InterfaceType::HardwareSerial: return "hwser";
+      default:                            return "";
+    }
+  }
 
 public:
   bool addInterface(InterfaceType type, BaseSerialInterface* iface) {
@@ -57,6 +89,9 @@ public:
     for(int i = 0; i < MAX_INTERFACES; i++){
       if(_interfaces[i].instance == iface){
         _interfaces[i] = {};
+        // The next addInterface() reuses this slot, so a stale id or pin would be inherited.
+        _client_ids[i][0] = 0;
+        if(_reply_idx == i) _reply_idx = -1;
         return true;
       }
     }
@@ -157,16 +192,44 @@ public:
     return false;
   }
 
+  // Replies go to the client that asked, which is what BaseSerialInterface documents this for.
+  // Fanning out instead injects one client's response into another's stream.
   size_t writeFrame(const uint8_t src[], size_t len) override {
+    if(!_enabled || len == 0){
+      return 0;
+    }
+
+    if(_reply_idx >= 0){
+      // A pin to a slot that no longer holds an interface is still a target, just a dead one.
+      // Broadcasting here would put a targeted reply into the other clients' streams.
+      if(!validIdx(_reply_idx)) return 0;
+
+      BaseSerialInterface* target = _interfaces[_reply_idx].instance;
+      if(target->isEnabled() && target->isConnected()){
+        return target->writeFrame(src, len);
+      }
+      // The target went away, so the frame was not delivered.
+      // Callers commit history on a full-length return, so reporting success would drop it.
+      return 0;
+    }
+
+    // Nothing has been received yet, so there is no reply target and a push reaches everyone.
+    return writeFrameToAll(src, len);
+  }
+
+  size_t writeFrameToAll(const uint8_t src[], size_t len) override {
     // don't write when disabled or nothing provided
     if(!_enabled || len == 0){
       return 0;
     }
 
-    // write frame to all enabled interfaces
+    // Success is judged only on interfaces holding a client.
+    // ArduinoSerialInterface::writeFrame() returns 0 until a companion client has spoken, so counting an idle USB would fail every write.
+    // Callers treat 0 as failure and retry, which would re-send the same frame to the transports that did succeed.
+    // With nothing connected this reports success for a frame that went nowhere, matching MultiTransportCompanionInterface::writeFrameToAll().
     bool allSuccessful = true;
     for(auto iface : _interfaces){
-      if(iface.instance && iface.instance->isEnabled()){
+      if(iface.instance && iface.instance->isEnabled() && iface.instance->isConnected()){
         if(iface.instance->writeFrame(src, len) != len){
           allSuccessful = false;
         }
@@ -174,8 +237,9 @@ public:
     }
 
     // report success if all writes completed successfully
-    return allSuccessful ? len : 0; 
+    return allSuccessful ? len : 0;
   }
+
 
   size_t checkRecvFrame(uint8_t dest[]) override {
     // don't read when disabled
@@ -184,17 +248,54 @@ public:
     }
 
     // try to read a frame from any enabled interface
-    for(auto iface : _interfaces){
+    for(int i = 0; i < MAX_INTERFACES; i++){
+      auto& iface = _interfaces[i];
       if(iface.instance && iface.instance->isEnabled()){
         size_t frameSize = iface.instance->checkRecvFrame(dest);
         if(frameSize > 0){
-          return frameSize; 
+          _reply_idx = i;
+          return frameSize;
         }
       }
     }
 
     // no frame received
     return 0;
+  }
+
+  // MyMesh pins the target across a contact list sync so CONTACT and END reach whoever got START.
+  int getReplyTarget() const override { return _reply_idx; }
+  void setReplyTarget(int target) override {
+    if(target < 0 || target >= MAX_INTERFACES){
+      _reply_idx = -1;
+    } else {
+      _reply_idx = target;
+    }
+  }
+
+  void setCurrentClientId(const char* id) override {
+    if(!validIdx(_reply_idx)) return;
+    char* slot = _client_ids[_reply_idx];
+    if(id == nullptr){
+      slot[0] = 0;
+      return;
+    }
+    size_t i = 0;
+    while(id[i] && i < MULTI_SERIAL_CLIENT_ID_LEN){ slot[i] = id[i]; i++; }
+    slot[i] = 0;
+  }
+
+  void getCurrentClientId(char* dest, size_t max_len) const override {
+    if(dest == nullptr || max_len == 0) return;
+    dest[0] = 0;
+    if(!validIdx(_reply_idx)) return;
+
+    // An id the app supplied wins, otherwise the transport's own name keeps histories apart.
+    const char* src = _client_ids[_reply_idx][0] ? _client_ids[_reply_idx]
+                                                 : defaultClientId(_interfaces[_reply_idx].type);
+    size_t i = 0;
+    while(src[i] && i + 1 < max_len){ dest[i] = src[i]; i++; }
+    dest[i] = 0;
   }
 
 };

--- a/src/helpers/ethernet/SerialEthernetInterface.h
+++ b/src/helpers/ethernet/SerialEthernetInterface.h
@@ -44,6 +44,10 @@ class SerialEthernetInterface : public BaseSerialInterface {
     }
     bool begin();
 
+    // Sets the DHCP client hostname, which drivers without netif support decline.
+    // Call after begin() so the interface exists, and before the link comes up so the lease carries it.
+    virtual bool setHostname(const char* hostname) { (void)hostname; return false; }
+
     void onClientConnected();
 
     // BaseSerialInterface methods

--- a/src/helpers/ethernet/ch390/CH390EthernetInterface.cpp
+++ b/src/helpers/ethernet/ch390/CH390EthernetInterface.cpp
@@ -56,6 +56,20 @@ bool CH390EthernetInterface::begin() {
   return true;
 }
 
+bool CH390EthernetInterface::setHostname(const char* hostname) {
+  if (!CH390.setHostname(hostname)) return false;
+
+  // The hostname is copied into the DISCOVER, so a client already running carries the old one.
+  // Restarting it costs nothing before link-up and guarantees the first lease carries the name.
+  // A static address configuration has already stopped the client.
+  // Restarting it there would discard that address and wait on a server the build does not use.
+#if !(defined(ETHERNET_STATIC_IP) && defined(ETHERNET_STATIC_GATEWAY) && defined(ETHERNET_STATIC_SUBNET))
+  CH390.disableDHCP();
+  CH390.enableDHCP();
+#endif
+  return true;
+}
+
 int CH390EthernetInterface::available() {
   return client.available();
 }

--- a/src/helpers/ethernet/ch390/CH390EthernetInterface.h
+++ b/src/helpers/ethernet/ch390/CH390EthernetInterface.h
@@ -19,6 +19,7 @@ class CH390EthernetInterface : public SerialEthernetInterface {
     }
     
     bool begin();
+    bool setHostname(const char* hostname) override;
     void loop() override;
 
     // BaseSerialInterface methods

--- a/variants/thinknode_m7/ThinkNodeM7Board.cpp
+++ b/variants/thinknode_m7/ThinkNodeM7Board.cpp
@@ -2,6 +2,20 @@
 
 void ThinkNodeM7Board::begin() {
   ESP32Board::begin();
+
+  // A pin left as INPUT sources no current, so the LED that onBeforeTransmit() drives stays dark.
+  // Both are active low, so the idle level is HIGH.
+#ifdef P_LORA_TX_LED
+  // HIGH rather than !LED_STATE_ON deliberately.
+  // LED_STATE_ON describes the status LED, not this one.
+  // This LED takes its polarity from onAfterTransmit() below, which writes HIGH to turn it off.
+  pinMode(P_LORA_TX_LED, OUTPUT);
+  digitalWrite(P_LORA_TX_LED, HIGH);
+#endif
+#ifdef PIN_STATUS_LED
+  pinMode(PIN_STATUS_LED, OUTPUT);
+  digitalWrite(PIN_STATUS_LED, !LED_STATE_ON);
+#endif
 }
 
 void ThinkNodeM7Board::enterDeepSleep(uint32_t secs, int pin_wake_btn) {

--- a/variants/thinknode_m7/platformio.ini
+++ b/variants/thinknode_m7/platformio.ini
@@ -46,7 +46,6 @@ build_flags =
   -D ETH_SCLK_PIN=47
   -D ETH_CS_PIN=21
   -D ETH_INT_PIN=45
-  -D ETHERNET_DEBUG_LOGGING=1
 build_src_filter =
   +<helpers/ethernet/*.cpp>
   +<helpers/ethernet/ch390/>
@@ -167,6 +166,7 @@ build_src_filter = ${ThinkNode_M7.build_src_filter}
   ${ThinkNode_M7_ethernet.build_src_filter}
   +<helpers/esp32/*.cpp>
   +<helpers/ui/MomentaryButton.cpp>
+  +<helpers/ui/NullDisplayDriver.cpp>
   +<../examples/companion_radio/*.cpp>
   +<../examples/companion_radio/ui-orig/*.cpp>
 lib_deps = ${ThinkNode_M7.lib_deps}


### PR DESCRIPTION
## Summary

Makes the Elecrow ThinkNode M7 ([#41](https://github.com/ALLFATHER-BV/meshcomod/issues/41)) actually work, and fixes three defects found along the way that are **not** M7-specific. All four trace back to the 1.17.0 merge, and one of them bootloops any freshly-flashed board regardless of variant.

Validated on real M7 hardware — the first known instance of meshcomod running on this board.

## Why these were invisible

`3c74dba8` ("Merge remote-tracking branch 'upstream/main' into upstream-v1.17.0-merge") resolved `examples/companion_radio/main.cpp` by keeping this fork's older single-`serial_interface` design and discarding upstream's rewritten version wholesale. That single resolution produced three of the four defects below.

`pr-build-check.yml` builds only three Heltec `*_usb_tcp` envs, none of which exercise `ui-orig`, the plain `*_repeater` envs, or any Ethernet board — so none of this surfaced in CI.

## The fixes

### 1. Bootloop on first boot with no stored contacts — affects every board

The most important one. `resetContacts()` seeds `num_contacts = MAX_ANON_CONTACTS` (8) while `contacts` is still unallocated: this fork allocates the table lazily into PSRAM, where upstream uses a static array that is always indexable. On a device with no stored contacts, nothing ever allocates it, and `bootstrapRTCfromContacts()` walks a null pointer.

```
Guru Meditation Error: Core 1 panic'ed (LoadProhibited)
EXCVADDR: 0x00000088                       <- offsetof(ContactInfo, lastmod)
BaseChatMesh::bootstrapRTCfromContacts()   BaseChatMesh.cpp:69
MyMesh::begin(bool)                        MyMesh.cpp:2480
setup()                                    main.cpp:341
```

`bootstrapRTCfromContacts()` arrived with the 1.17.0 merge (upstream `df668703`), so this is latent on `main` for **all** boards. An upgraded device survives only because SPIFFS sits at `0x670000`, past the end of a merged image, and keeps its contacts; a freshly flashed one does not. The M7 was simply the first genuinely-empty device to run 1.17.0.

Fixed at the class rather than the call site: the allocation moves into `ensureContacts()`, called from `bootstrapRTCfromContacts()` — which runs at `begin()` with PSRAM up. The table then exists for the rest of runtime, which also covers `searchPeersByHash()`, `lookupContactByPubKey()` and `scanRecentContacts()`, all of which loop the same reserved slots and would have faulted on the first inbound packet.

Worth noting `resetContacts()` already carried a guard for this exact hazard — its comment says doing the memset unguarded "NULL-derefs on boot". The new upstream caller just didn't know about the invariant.

### 2. `ui-orig` UITask constructor takes a type nothing constructs

Upstream `e672679d` narrowed the constructor to `MultiSerialInterface*` in `ui-orig` and `ui-tiny`. Since the merge kept the fork's `main.cpp`, nothing builds a `MultiSerialInterface`, so no call site matches:

```
ui-orig/UITask.h:64: error: 'MultiSerialInterface' has not been declared
main.cpp:121: error: no matching function for call to
  'UITask::UITask(ThinkNodeM7Board*, ArduinoSerialInterface*)'
```

Nothing in the UI touches `_serial` directly — `AbstractUITask` holds it as a `BaseSerialInterface*` and every accessor goes through that — so the narrower type bought nothing. `ui-new/UITask.h`, used by 56 variants including every release board, already takes `BaseSerialInterface*`; this restores parity.

**Scope, measured rather than assumed.** Of the ten `ui-orig` variants only two are ESP32 — `thinknode_m7` and `rak3112` — and both are unblocked by this change: `RAK_3112_companion_radio_ble` fails on `main` with exactly the error above and builds afterwards.

The other eight are nRF52 (`minewsemi_me25ls01`, `muziworks_r1_neo`, `meshtracker_x1`, `thinknode_m3`, `rak_wismesh_tag`, `t1000-e`, `xiao_nrf52`) or STM32 (`wio-e5-mini`), and still fail on a **separate pre-existing defect this PR does not address**: the `PsAlloc` allocator at `MyMesh.cpp:1540` calls `heap_caps_malloc` / `MALLOC_CAP_SPIRAM` with no ESP32 guard, so no non-ESP32 companion builds at all. On `main` those variants report both errors; on this branch, only that one.

### 3. M7 `_ethernet` env missing `NullDisplayDriver.cpp`

Sets `-D DISPLAY_CLASS=NullDisplayDriver` but omits the source file its `_ble` and `_wifi` siblings both carry, so the link fails on `undefined reference to UIColor::primary_txt`.

### 4. Companion Ethernet transport restored

MeshCore added companion Ethernet in `5de857f8` and generalised it in `e672679d` into a `MultiSerialInterface` registering USB, Ethernet, BLE, Wi-Fi and hardware serial simultaneously. The merge dropped it:

| commit | `ETHERNET_ENABLED` occurrences in companion `main.cpp` |
|---|---|
| `727fc051` (MeshCore parent) | 2 |
| `3c74dba8` (the merge) | 0 |

The driver kept compiling but nothing constructed it, so the linker dropped `CH390EthernetInterface` from the image entirely — Ethernet boards came up with **no link at all**. It also left `ENABLE_USB_INTERFACE` as a dead flag, still set by `ThinkNode_M7_companion_radio_usb` but referenced nowhere.

Restored using `MultiSerialInterface`, which was already in the tree and otherwise unused. Guarded by `COMPANION_USB_ETHERNET` and deliberately ordered after `BLE_PIN_CODE`, so `*_companion_radio_ble` keeps its existing behaviour and only Ethernet-only envs change. Also drives `serial_interface.loop()` — nothing in this fork called `BaseSerialInterface::loop()`, which the other transports don't need but the Ethernet one uses to accept clients.

Symbols before and after, same env:

| | before | after |
|---|---|---|
| `CH390EthernetInterface` | absent (linker dropped it) | 7 symbols |
| `MultiSerialInterface` | absent | 9 symbols |

### 5. An idle USB transport no longer fails multi-interface writes

`MultiSerialInterface::writeFrame()` required every *enabled* interface to write the full frame, but `ArduinoSerialInterface::writeFrame()` returns 0 until a client has spoken, so an idle USB made every write report failure. Callers retry on 0 — MyMesh's contact sync loops `while (sent == 0)` (MyMesh.cpp:4156) — so each frame would exhaust its retries and be re-sent to Ethernet every pass. Success is now judged only on interfaces holding a client, matching `MultiTransportCompanionInterface::writeFrameToAll()`. Found by Copilot review; masked during hardware testing because a USB client was attached throughout.

### 6. The node name is sent as the DHCP hostname

With no hostname option the lease carries only lwIP's `CONFIG_LWIP_LOCAL_HOSTNAME`, so the node is reachable only by an address that changes with the lease.

The node name is free text and a hostname is not, so it is reduced to an RFC 1123 label: non-alphanumerics become hyphens, runs collapse, the edges are trimmed, output is lowercased, and an empty result falls back to `meshcore`. The read is bounded by the array length rather than by a terminator, since `NodePrefs::node_name` can load unterminated.

`setHostname()` is virtual on `SerialEthernetInterface` and declines by default, so a driver with no netif support is unaffected. The CH390 override sets the name and restarts the DHCP client, because the hostname is copied into DISCOVER and a client already running carries the previous one. A build configured with a static address skips that restart, since `ESP32_CH390::config()` has already stopped the client.

mDNS answers for the same label, so the name resolves whether or not the DHCP server registers it.

### 7. LED pins are configured, so both LEDs work

`ThinkNodeM7Board::begin()` forwarded to the base and never called `pinMode()`, so `onBeforeTransmit()` wrote to pins still in their default INPUT state, which source no current. Both LEDs were dead on this board. Confirmed fixed on hardware: the green LED now shows its designed heartbeat, a 20 ms blip every 4 s that lengthens to 200 ms while messages are unread (`ui-orig/UITask.cpp:386`).

## The ethernet MAC, and why this PR does not change it

This platform builds with `CONFIG_ESP32S3_UNIVERSAL_MAC_ADDRESSES=2`. With two universal addresses the ESP-IDF does not read a universal ethernet address, it derives one: it takes the Bluetooth address and sets the locally administered bit. Taking an illustrative base of `00:00:5E:00:53:00`, that yields Bluetooth `00:00:5E:00:53:01` and ethernet `02:00:5E:00:53:01`, which differs from the base in both the first and last octet and carries no vendor OUI.

For comparison, ESPHome on the same board reports base+3, `00:00:5E:00:53:03`. It builds with four universal addresses, where ethernet is base+3, and assigns it explicitly with `esp_read_mac(mac, ESP_MAC_ETH)` then `esp_eth_ioctl(ETH_CMD_S_MAC_ADDR)` before attaching the netif. The CH390 driver here does neither, so the derived address stands.

`esp_read_mac(ESP_MAC_ETH)` cannot be used to match that: under a two-address configuration it returns the derived value, so reading it and writing it back is a no-op. Reaching base+3 requires changing the universal address count.

That change is deliberately not made. The address is a device's identity on the network, so moving it turns every deployed unit into an unfamiliar device on upgrade, discarding whatever its current address is bound to: DHCP reservations, DNS records, firewall rules and access policies.

## Hardware validation

On a real ThinkNode M7:

- Boots — `[BOOT] board ok`, `[BOOT] radio ok`; the LR1110 initialises.
- BLE companion pairs from the MeshCore client.
- USB companion connects from the web client.
- Ethernet: link, DHCP lease, `ETH: listening on TCP port: 5000`, `[BOOT] usb+ethernet ok`, with USB live at the same time.

- Home Assistant connects over the Ethernet TCP transport and reads telemetry.
- Both LEDs work. Green shows the firmware heartbeat, blue follows LoRa transmit.
- The compiled radio defaults seed a fresh device. After the store was cleared the node came up on 927.875 MHz, 62.5 kHz, SF7, CR5 with no client involvement.

Nothing in this PR is left unverified on hardware.

## CI validation, run manually

Both PR workflows, locally, with no extra build flags:

- `pio test -e native -e native_kiss_modem` — **33/33 pass**
- `pio run -e Heltec_v3_companion_radio_usb_tcp` — SUCCESS
- `pio run -e heltec_v4_companion_radio_usb_tcp` — SUCCESS
- `pio run -e heltec_v4_tft_companion_radio_usb_tcp_touch` — SUCCESS

Plus all five buildable M7 envs.

## Deliberately out of scope

Found while working, left alone — each wants its own change:

- **`*_repeater` envs don't build on any board.** `examples/simple_repeater/UITask.cpp` uses `DisplayDriver::BLUE` / `DisplayDriver::LIGHT`, but that `enum Color` is commented out at `src/helpers/ui/DisplayDriver.h:20`, superseded by the `UIColor` statics. Reproduced identically on `Station_G3_ESP32_repeater`, so it is not M7-specific. This is why `ThinkNode_M7_repeater` is absent from the validated list.
- **`ui-tiny/UITask.h`** carries the same constructor break fixed here for `ui-orig`, affecting `LilyGo_T-Echo_Card_companion_radio_ble` and `_usb` on nRF52, where `main.cpp` never builds a `MultiSerialInterface`.
- **`ThinkNode_M7_companion_radio_ble` has unused Ethernet.** The env sets both `BLE_PIN_CODE` and the CH390 flags. `MultiSerialInterface` can register BLE, USB and Ethernet together; wiring that up would give the board every transport at once, but it changes a working env and needs its own hardware validation.
- **No non-ESP32 companion builds at all.** `MyMesh.cpp:1540` uses `heap_caps_malloc` / `heap_caps_free` / `heap_caps_realloc` / `MALLOC_CAP_SPIRAM` in the `PsAlloc` ArduinoJson allocator with no ESP32 guard, so every nRF52 and STM32 companion env fails to compile. Confirmed on `main`, independent of this branch. Same underlying pattern as defect 1: a PSRAM optimisation leaking ESP32-only assumptions into shared companion code.
- **A mains powered device reports a battery.** `ESP32Board::getBattMilliVolts()` returns 0 unless `PIN_VBAT_READ` is defined, and the M7 defines no such pin because the board is powered over PoE or USB and carries no cell. Zero is indistinguishable from a flat battery, so every client presents the node as critically discharged. The protocol has no way to say a device has no battery, which is where the fix belongs: a device with no cell should report absence rather than zero, and a board should be able to declare that it is externally powered.
- **The Home Assistant integration exposes battery entities for a device with no battery.** It creates Battery Percentage and Battery Voltage from that zero, so the node shows 0 percent with a low-battery icon and will drive any automation or alert keyed on battery level. Until the protocol can express absence, those entities should be omitted or reported unavailable for a device that reports no cell rather than published as a real reading.
- **The meshcomod web client mis-parses `RESP_CODE_DEVICE_INFO`, and the offset is known.** It renders that field as mojibake followed by the build date and manufacturer name run together. Decoded against the frame, which this PR does not change: byte 2 is `MAX_CONTACTS / 2`, 175, invalid UTF-8 and rendered as the replacement character, byte 3 is `MAX_GROUP_CHANNELS`, 40, rendered as an open bracket, bytes 8 to 19 are the build date and bytes 20 on are the manufacturer name. The client begins reading at offset 2 rather than offset 8, skipping the two byte header but neither the two v3+ count bytes nor the four byte BLE pin, and runs through the null separators instead of stopping. The same client parses `Device model` and `Firmware` correctly out of that frame and Home Assistant renders it correctly, so the frame is well formed and `StrHelper::strzcpy` pads every field. The fix belongs in that client.
- **The same client reports a battery voltage the firmware never sent.** It has shown 7.04 V, 2.56 V and 0.000 V for a board with no cell, where Home Assistant renders 0.000 V from the same device. The firmware reports zero, so the value is invented by that client's parsing and the fix belongs with the frame offset above.
- **`boards/thinknode_m7.json` `hwids`** declare `0x303A:0x1001` (Espressif native USB); the board actually enumerates as a WCH CH343 bridge, `0x1a86:0x7522`. Breaks PlatformIO port auto-detection.

## Review notes

Two things I'd particularly like scrutinised:

1. `ensureContacts()` allocates on first call from `bootstrapRTCfromContacts()`, so the table now exists from `begin()` onward rather than on first contact insert. That is intentional — it restores the invariant the rest of the code assumes — but it does mean a device with zero contacts holds the allocation it previously deferred.
2. `COMPANION_USB_ETHERNET` is deliberately ordered after `BLE_PIN_CODE` so `*_companion_radio_ble` behaviour is untouched. The cost is that the M7 BLE env keeps its unused Ethernet; combining all three transports is possible but wanted its own validation.
